### PR TITLE
better error message for not finding config file + small other fix + added tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.21.0"
+      
+      - name: Run Go Tests
+        run: go test -v ./...
 
       - name: Build
         run: go build -o ./build/ -v ./...

--- a/aws/helpers.go
+++ b/aws/helpers.go
@@ -56,7 +56,7 @@ func GetInstanceStatus(ctx context.Context, c *ec2.Client, logger *zerolog.Logge
 
 		for _, r := range result.SpotInstanceRequests {
 			if *r.Status.Code == "instance-terminated-by-price" {
-				logger.Info().Msgf("instance % is about to be terminated with code %s", *r.InstanceId, *r.Status.Code)
+				logger.Info().Msgf("instance %s is about to be terminated with code %s", *r.InstanceId, *r.Status.Code)
 				sc <- *r.Status.Code
 			}
 		}

--- a/utils/config.go
+++ b/utils/config.go
@@ -96,7 +96,7 @@ func InitCedanaConfig() (*CedanaConfig, error) {
 	var config CedanaConfig
 	err = viper.ReadInConfig()
 	if err != nil {
-		panic("error loading config file. Make sure that config exists in $HOME/.cedana/cedana_config.json and that it's formatted correctly!")
+		return nil, fmt.Errorf("error loading config file: %s. Make sure that config exists and that it's formatted correctly!", err)
 	}
 
 	if err := viper.Unmarshal(&config); err != nil {

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"testing"
+	"os"
+	"fmt"
+)
+
+const CEDANA_ENV_ENV_VAR = "CEDANA_ENV"
+
+func TestMain(m *testing.M) {
+	originalEnv := os.Getenv(CEDANA_ENV_ENV_VAR)
+    code := m.Run() 
+	os.Setenv(CEDANA_ENV_ENV_VAR, originalEnv)
+    os.Exit(code)
+}
+
+func TestCannotFindConfigFile(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Error(err)
+	}
+	
+	_, err = InitCedanaConfig()
+	expectedErrorMessage := fmt.Sprintf(
+		"error loading config file: Config File \"cedana_config\" Not Found in \"[%s/.cedana]\". Make sure that config exists and that it's formatted correctly!",
+		homeDir,
+	)
+
+
+	if err.Error() != expectedErrorMessage {
+		t.Errorf("unexpected error \"%s\" != \"%s\"", err, expectedErrorMessage)
+	}
+}
+
+func TestCannotFindConfigFileInDevEnv(t *testing.T) {
+	os.Setenv("CEDANA_ENV", "dev")
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Error(err)
+	}
+	
+	_, err = InitCedanaConfig()
+	expectedErrorMessage := fmt.Sprintf(
+		"error loading config file: Config File \"cedana_config_dev\" Not Found in \"[%s/.cedana]\". Make sure that config exists and that it's formatted correctly!",
+		homeDir,
+	)
+
+
+	if err.Error() != expectedErrorMessage {
+		t.Errorf("unexpected error \"%s\" != \"%s\"", err, expectedErrorMessage)
+	}
+}


### PR DESCRIPTION
Since the config file name changes based on the value of the env var `CEDANA_ENV`, the static error message could be incorrect when not finding the config file: it was hard-coded to `cedana_config`.

Updated it to return the error from `viper` which includes the expected file name. Also made the function _return_ the error, which is nicer and more testable.

error now looks like this:

```
$ CEDANA_ENV=dev ./cedana-cli run examples/loop.yml 
8:23AM FTL could not set up config error="error loading config file: Config File \"cedana_config_dev\" Not Found in \"[/Users/username/.cedana]\". Make sure that config exists and that it's formatted correctly!"
```

Added tests for this.

Fixed another small bug.

Added `go test ./...` to ci workflow