### PR TITLE
fix: need to account for error being nil in TestCannotFindConfigFile

### DIFF
--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -29,7 +29,7 @@ func TestCannotFindConfigFile(t *testing.T) {
 	)
 
 
-	if err.Error() != expectedErrorMessage {
+	if err != nil && err.Error() != expectedErrorMessage {
 		t.Errorf("unexpected error \"%s\" != \"%s\"", err, expectedErrorMessage)
 	}
 }


### PR DESCRIPTION
in `TestCannotFindConfigFile`, there wasn't a check for the `err` not to be `nil` before calling `err.Error()`, this fixes that.