### PR TITLE
fix: added way to set "cedana path" in code

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -64,16 +64,28 @@ type Checkpoint struct {
 }
 
 /*
-	configFile represents an override to the location of the cedana config file
+configFile represents an override to the location of the cedana config file
 */
 var configFile string = ""
 
+/*
+cedanaPath represents the folder that stores the config file
+*/
+var cedanaPath string = ".cedana/"
 
 /*
-	SetConfigFile overrides the path to the cedana config file
+SetConfigFile overrides the path to the cedana config file
 */
 func SetConfigFile(c string) {
 	configFile = c
+}
+
+func SetCedanaPath(p string) {
+	cedanaPath = p
+}
+
+func GetCedanaPath() string {
+	return cedanaPath
 }
 
 func InitCedanaConfig() (*CedanaConfig, error) {
@@ -99,7 +111,7 @@ func InitCedanaConfig() (*CedanaConfig, error) {
 	if configFile != "" {
 		viper.SetConfigFile(configFile)
 	} else {
-		viper.AddConfigPath(filepath.Join(homedir, ".cedana/"))
+		viper.AddConfigPath(filepath.Join(homedir, cedanaPath))
 		// change config if dev environment
 		if os.Getenv("CEDANA_ENV") == "dev" {
 			viper.SetConfigName("cedana_config_dev")
@@ -107,7 +119,7 @@ func InitCedanaConfig() (*CedanaConfig, error) {
 			viper.SetConfigName("cedana_config")
 		}
 	}
-	
+
 	viper.AutomaticEnv()
 
 	var config CedanaConfig


### PR DESCRIPTION
when running tests, if you had a config file saved in "~/.cedana", you would have tests fail.  the tests that failed were those that checked for a specific error if that file didn't exist.  this commit allows a user, in code (maybe this could be a future cli feature?) to set the path of cedana config file only.  this allows us to create a non-conflicting cedana path to use with tests (or other uses).